### PR TITLE
Don't use a hard-coded path when trying to access markdown

### DIFF
--- a/makepdfs.js
+++ b/makepdfs.js
@@ -97,7 +97,7 @@ if (!fs.existsSync(dir)){
 fs.readdir (mddir,function(err, files) {
    for (let file of files) {
       if (path.extname(file) == '.md') {				 
-				var text = fs.readFileSync('doc/' + file).toString('utf-8');
+				var text = fs.readFileSync(mddir + '/' + file).toString('utf-8');
 				var md = require('markdown-it')({
 					html: true,
 					breaks: true,


### PR DESCRIPTION
While we're looking for markdown files in the correct directory passed in by `markdown_dir`, accessing them failed because there was a hard-coded `doc` string in the `fs.readFileSync` call.