### PR TITLE
fix puppeteer to 5.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
       libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget curl && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install puppeteer markdown-it mustache markdown-it-named-headers cheerio markdown-it-highlightjs
+RUN npm install puppeteer@5.2.1 markdown-it mustache markdown-it-named-headers cheerio markdown-it-highlightjs
 COPY makepdfs.js /
 COPY package.json /
 COPY template/ template/

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "puppeteer": "1.15.0",
+    "puppeteer": "5.2.1",
     "commander": "2.20.0",
-    "markdown-it": "11.0.0"
+    "markdown-it": "11.0.0",
     "markdown-it-highlightjs": "3.2.0"
   }
 }


### PR DESCRIPTION
By locking puppeteer to 5.2.1 the GH-action works again. Fixes  #7
For users to use this, the latest docker image must be build and deployed.