### PR TITLE
Add multimedia support to the action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ This action creates PDF documents from github markdown
 
 **Required** Location to output PDF files to. Default `tmp`.
 
+### `media_dir`
+
+**Optional** Location where media files such as images and gifs which are 
+embedded in Markdown files are stored. Default to `doc/img` Keep in mind 
+that all media files need to be referenced in markdown files as follows: 
+`[Alt Text](http://localhost:3000/image_name.jpg)`. 
+
+This is due to security features in puppeteer which prevent referencing 
+local images embedded in HTML.
+
 ## Example usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This action creates PDF documents from github markdown
 **Optional** Location where media files such as images and gifs which are 
 embedded in Markdown files are stored. Default to `doc/img` Keep in mind 
 that all media files need to be referenced in markdown files as follows: 
-`[Alt Text](http://localhost:3000/image_name.jpg)`. 
+`![Alt Text](http://localhost:3000/image_name.jpg)`. 
 
 This is due to security features in puppeteer which prevent referencing 
 local images embedded in HTML.

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Location to output PDF files to'
     required: true
     default: 'tmp'
+  media_dir:
+    description: 'Location of local media files (images, gifs) for the markdown files'
+    required: false
+    default: 'doc/img'
 
 branding:
   icon: 'activity'

--- a/makepdfs.js
+++ b/makepdfs.js
@@ -48,7 +48,7 @@ function makePdf(data,file) {
 	try {
 		file  = file.replace('.md','');
 		const puppeteer = require('puppeteer');
-    const express = require('express');
+  		const express = require('express');
 		(async () => {
 
         //Create server for images
@@ -77,7 +77,7 @@ function makePdf(data,file) {
 			});
 
 			await browser.close();
-      await server.close();
+                        await server.close();
 		  })();
 	} catch (error) {
 		showErrorMessage('makeHtml()', error);

--- a/makepdfs.js
+++ b/makepdfs.js
@@ -2,14 +2,16 @@
 
 const markdown_dir = process.env.INPUT_MARKDOWN_DIR;
 const output_dir = process.env.INPUT_OUTPUT_DIR;
+const media_dir = process.env.INPUT_MEDIA_DIR;
 
 'use strict';
 var fs = require( 'fs' );
 var mddir = '/github/workspace/' + markdown_dir;
 var dir = '/github/workspace/' + output_dir + '/';
+var meddir = '/github/workspace' + media_dir + '/';
 
-/* 
- * Show an error message 
+/*
+ * Show an error message
  */
 function showErrorMessage(msg, error) {
 	console.log('ERROR: ' + msg);
@@ -28,7 +30,7 @@ function makeHtml(data) {
 		var template = fs.readFileSync("/template/template.html").toString('utf-8');
 		// compile template
 		var mustache = require('mustache');
-  
+
 		var view = {
 			style: style,
 			content: data
@@ -46,7 +48,14 @@ function makePdf(data,file) {
 	try {
 		file  = file.replace('.md','');
 		const puppeteer = require('puppeteer');
+    const express = require('express');
 		(async () => {
+
+        //Create server for images
+        const app = express();
+        app.use(express.static(meddir));
+        server = app.listen(3000);
+
 				const browser = await puppeteer.launch( {
 				executablePath:'/node_modules/puppeteer/.local-chromium/linux-782078/chrome-linux/chrome',
 				args: [
@@ -66,8 +75,9 @@ function makePdf(data,file) {
 				footerTemplate: '<div class="pageNumber" style="font-size:8px;width:100%;text-align:center;"></div>',
 				headerTemplate: '<div class="date" style="font-size:8px;width:100%;text-align:center;"></div>'
 			});
-		  
+
 			await browser.close();
+      await server.close();
 		  })();
 	} catch (error) {
 		showErrorMessage('makeHtml()', error);
@@ -94,9 +104,13 @@ if (!fs.existsSync(dir)){
     fs.mkdirSync(dir);
 }
 
+if (!fs.existsSync(meddir)){
+    fs.mkdirSync(meddir);
+}
+
 fs.readdir (mddir,function(err, files) {
    for (let file of files) {
-      if (path.extname(file) == '.md') {				 
+      if (path.extname(file) == '.md') {
 				var text = fs.readFileSync(mddir + '/' + file).toString('utf-8');
 				var md = require('markdown-it')({
 					html: true,
@@ -107,7 +121,7 @@ fs.readdir (mddir,function(err, files) {
 							str = hljs.highlight(lang, str, true).value;
 						} catch (error) {
 							str = md.utils.escapeHtml(str);
-				
+
 							showErrorMessage('markdown-it:highlight', error);
 						}
 						} else {


### PR DESCRIPTION
I've added some workaround logic to overcome a limitation which prevents the use of embedded images in markdown.

The workaround uses a local webserver to host the images instead of referencing them as local files. For why I used this approach, see [this puppeteer issue](https://github.com/puppeteer/puppeteer/issues/1643).

Should fix #18 and #19.

Hopefully everything is up to your standards and works properly. I'm very new to javascript and haven't had the time to test thoroughly yet.