### PR TITLE
Add express to dependencies and fix `Module 'express' not found`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
       libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget curl && \
     rm -rf /var/lib/apt/lists/*
 
-RUN npm install puppeteer@5.2.1 markdown-it mustache markdown-it-named-headers cheerio markdown-it-highlightjs markdown-it-table-of-contents markdown-it-anchor
+RUN npm install puppeteer@5.2.1 markdown-it mustache markdown-it-named-headers cheerio markdown-it-highlightjs markdown-it-table-of-contents markdown-it-anchor express
 COPY makepdfs.js /
 COPY package.json /
 COPY template/ template/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN npm install puppeteer@5.2.1 markdown-it mustache markdown-it-named-headers cheerio markdown-it-highlightjs markdown-it-table-of-contents markdown-it-anchor express
+RUN npm ci
 COPY makepdfs.js /
 COPY package.json /
 COPY template/ template/

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "markdown-it-table-of-contents": "0.5.2",
     "markdown-it-anchor": "8.1.2",
     "markdown-it-named-headers": "0.0.4",
-    "mustache": "4.2.0"
+    "mustache": "4.2.0",
+    "express": "4.17.3"
   }
 }


### PR DESCRIPTION
Fixes this
```
{ Error: Cannot find module 'express'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:6[9](https://github.com/Explosion-Scratch/notion_backup/runs/5249869358?check_suite_focus=true#step:4:9)2:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at makePdf (/makepdfs.js:51:21)
    at /makepdfs.js:[14](https://github.com/Explosion-Scratch/notion_backup/runs/5249869358?check_suite_focus=true#step:4:14)0:5
    at FSReqWrap.args [as oncomplete] (fs.js:140:20) code: 'MODULE_NOT_FOUND'
```